### PR TITLE
[Ads] Fix Ads

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,6 +12,8 @@ import PracticeModesScreen from './screens/PracticeModesScreen';
 import PracticeScreen from './screens/PracticeScreen';
 import CustomizeScreen from './screens/CustomizeScreen';
 
+import { configureAds } from './helpers/adHelpers';
+
 import {
   BRAIN_POWER,
   COMPLETED_LEVELS,
@@ -118,6 +120,8 @@ const App = props => {
   const [unlockedCustomizations, setUnlockedCustomizations] = useState([]);
   const [enabledCustomization, setEnabledCustomization] = useState(null);
   const [isFirstTimeOpeningApp, setIsFirstTimeOpeningApp] = useState(true);
+
+  configureAds();
 
   if (!isLoadingComplete && !props.skipLoadingScreen) {
     return (

--- a/components/Game.js
+++ b/components/Game.js
@@ -67,7 +67,7 @@ const Game = props => {
     setupGame(gameState);
     setMaxNodeSize(getMaxNodeSize(gameState.nums.length));
 
-    AdHelpers.configureAndRequestAd();
+    AdMobInterstitial.requestAdAsync().catch(e => console.log('error', e));
 
     return () => {
       AdMobInterstitial.removeEventListener('interstitialDidClose');

--- a/helpers/adHelpers.js
+++ b/helpers/adHelpers.js
@@ -3,47 +3,43 @@ import { AdMobInterstitial } from 'expo-ads-admob';
 import shouldShowAd from './shouldShowAd';
 import { ANDROID_GOOGLE_INTERSTITIAL_AD_UNIT_ID, IOS_GOOGLE_INTERSTITIAL_AD_UNIT_ID } from '../config';
 
-const configureAndRequestAd = async () => {
-  const isReady = await AdMobInterstitial.getIsReadyAsync();
-
-  if (!isReady) {
-    if (Platform.OS === 'ios') {
-      AdMobInterstitial.setAdUnitID(IOS_GOOGLE_INTERSTITIAL_AD_UNIT_ID);
-    }
-
-    if (Platform.OS === 'android') {
-      AdMobInterstitial.setAdUnitID(ANDROID_GOOGLE_INTERSTITIAL_AD_UNIT_ID);
-    }
-
-    AdMobInterstitial.setTestDeviceID('EMULATOR');
-    await AdMobInterstitial.requestAdAsync();
+const configureAds = () => {
+  if (Platform.OS === 'ios') {
+    AdMobInterstitial.setAdUnitID(IOS_GOOGLE_INTERSTITIAL_AD_UNIT_ID);
   }
+
+  if (Platform.OS === 'android') {
+    AdMobInterstitial.setAdUnitID(ANDROID_GOOGLE_INTERSTITIAL_AD_UNIT_ID);
+  }
+
+  AdMobInterstitial.setTestDeviceID('EMULATOR');
 };
 
-const showAd = async (afterAdAction, context) => {
+const showAd = async (actionAfterAdPlays, context) => {
   context.setLevelsPlayedBetweenAds(0);
 
   try {
-    const isReady = await AdMobInterstitial.getIsReadyAsync();
+    const adAlreadyRequested = await AdMobInterstitial.getIsReadyAsync();
 
-    if (isReady) {
-      await AdMobInterstitial.showAdAsync();
+    if (adAlreadyRequested) {
+      AdMobInterstitial.showAdAsync();
     } else {
-      await configureAndRequestAd();
-      await AdMobInterstitial.showAdAsync();
+      AdMobInterstitial.requestAdAsync()
+        .then(() => AdMobInterstitial.showAdAsync())
+        .catch(e => console.log('error', e));
     }
 
     AdMobInterstitial.addEventListener('interstitialDidClose', () => {
-      afterAdAction();
+      actionAfterAdPlays();
     });
 
     AdMobInterstitial.addEventListener('interstitialDidFailToLoad', () => {
-      afterAdAction();
+      actionAfterAdPlays();
     });
   } catch (error) {
     console.log('error from showAd', error);
-    afterAdAction();
+    actionAfterAdPlays();
   }
 };
 
-export { configureAndRequestAd, shouldShowAd, showAd };
+export { shouldShowAd, showAd, configureAds };


### PR DESCRIPTION
- This fixes the issue where Ads weren't playing in production or on the emulator
- There was an issue with the previously re-factored ads configuration code - there was an async function that wasn't returning anything (a similar issue is described here https://jakearchibald.com/2017/await-vs-return-vs-return-await/ )
- Also added test ad unit ids so ads will play consistently in iOS and Android emulators. Found here:

https://developers.google.com/admob/ios/test-ads
https://developers.google.com/admob/android/test-ads